### PR TITLE
Adding null privacy API provider.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,14 @@ cache:
     - $HOME/.composer/cache
 
 php:
- - 5.6
  - 7.0
 
 env:
  matrix:
   - DB=pgsql MOODLE_BRANCH=master
   - DB=mysqli MOODLE_BRANCH=master
-  - DB=pgsql MOODLE_BRANCH=MOODLE_31_STABLE
-  - DB=mysqli MOODLE_BRANCH=MOODLE_31_STABLE
+  - DB=pgsql MOODLE_BRANCH=MOODLE_35_STABLE
+  - DB=mysqli MOODLE_BRANCH=MOODLE_35_STABLE
 
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,22 @@
 language: php
 
-sudo: false
+sudo: true
+
+addons:
+  firefox: "47.0.1"
+  postgresql: "9.4"
+  apt:
+    packages:
+      - openjdk-8-jre-headless
 
 cache:
   directories:
     - $HOME/.composer/cache
+    - $HOME/.npm
 
 php:
  - 7.0
+ - 7.1
 
 env:
  matrix:
@@ -16,12 +25,12 @@ env:
   - DB=pgsql MOODLE_BRANCH=MOODLE_35_STABLE
   - DB=mysqli MOODLE_BRANCH=MOODLE_35_STABLE
 
-
 before_install:
   - phpenv config-rm xdebug.ini
+  - nvm install 8.9
+  - nvm use 8.9
   - cd ../..
-  - composer selfupdate
-  - composer create-project -n --no-dev --prefer-dist moodlerooms/moodle-plugin-ci ci ^1
+  - composer create-project -n --no-dev --prefer-dist blackboard-open-source/moodle-plugin-ci ci ^2
   - export PATH="$(cd ci/bin; pwd):$(cd ci/vendor/bin; pwd):$PATH"
 
 install:
@@ -32,9 +41,10 @@ script:
   - moodle-plugin-ci phpcpd
   - moodle-plugin-ci phpmd
   - moodle-plugin-ci codechecker
-  - moodle-plugin-ci csslint
-  - moodle-plugin-ci shifter
-  - moodle-plugin-ci jshint
   - moodle-plugin-ci validate
+  - moodle-plugin-ci savepoints
+  - moodle-plugin-ci mustache
+  - moodle-plugin-ci grunt
+  - moodle-plugin-ci phpdoc
   - moodle-plugin-ci phpunit
   - moodle-plugin-ci behat

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -29,7 +29,8 @@ defined('MOODLE_INTERNAL') || die();
 /**
  * Privacy Subsystem for tool_cohortautoroles.
  *
- * @copyright  2019 David Thompson <david.thompson@catalyst.net.nz>
+ * @copyright  Catalyst IT
+ * @author     2019 David Thompson <david.thompson@catalyst.net.nz>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class provider implements \core_privacy\local\metadata\null_provider {

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -22,15 +22,24 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace tool_cohortautoroles\privacy;
+
 defined('MOODLE_INTERNAL') || die();
 
-
-$plugin->version   = 2019071500; // The current plugin version (Date: YYYYMMDDXX).
-$plugin->requires  = 2016051900; // Requires this Moodle version.
-$plugin->component = 'tool_cohortautoroles'; // Full name of the plugin (used for diagnostics).
-$plugin->maturity = MATURITY_STABLE;
-$plugin->release = "1";
-
-$plugin->dependencies = array(
-    'tool_lp' => ANY_VERSION
-);
+/**
+ * Privacy Subsystem for tool_cohortautoroles.
+ *
+ * @copyright  2019 David Thompson <david.thompson@catalyst.net.nz>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class provider implements \core_privacy\local\metadata\null_provider {
+    /**
+     * Get the language string identifier with the component's language
+     * file to explain why this plugin stores no data.
+     *
+     * @return  string
+     */
+    public static function get_reason() : string {
+        return 'privacy:metadata';
+    }
+};

--- a/lang/en/tool_cohortautoroles.php
+++ b/lang/en/tool_cohortautoroles.php
@@ -43,3 +43,4 @@ $string['selectsysrole'] = 'Select role to identify the mentors';
 $string['taskname'] = 'Sync cohort auto role assignments';
 $string['thisuserroles'] = 'Roles assigned relative to this user';
 $string['sysrole'] = 'System Role used to identify mentors';
+$string['privacy:metadata'] = 'The Cohort auto roles plugin does not store any personal data.';


### PR DESCRIPTION
Added a null provider for the privacy API.

Unlike `tool_cohortroles`, autoroles uses an intermediary system role ID, so it is not directly attached to a user account. As such, it should be safe to use a null provider.